### PR TITLE
Add macro to enable/disable build BasisU as a tool

### DIFF
--- a/basisu_tool.cpp
+++ b/basisu_tool.cpp
@@ -2776,6 +2776,7 @@ static int main_internal(int argc, const char **argv)
 	return status ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
+#ifdef BASISU_UTILITY_BUILD
 int main(int argc, const char** argv)
 {
 #ifdef _DEBUG
@@ -2803,3 +2804,4 @@ int main(int argc, const char** argv)
 
 	return status;
 }
+#endif


### PR DESCRIPTION
The Basis repository contains a `main()` which must not be linked when building for RTC.

https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/819/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/820/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/821/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/822/downstreambuildview/