### PR TITLE
Remove 'basisu_tool.cpp' from build

### DIFF
--- a/basis_universal.lua
+++ b/basis_universal.lua
@@ -24,8 +24,6 @@ excludes {
 }
 
 files {
-  "encoder/**.h",
-  "encoder/**.cpp",
   "transcoder/**.h",
   "transcoder/**.cpp",
   "*.h",
@@ -34,7 +32,6 @@ files {
 }
 
 includedirs {
-  "encoder",
   "transcoder",
 }
 

--- a/basis_universal.lua
+++ b/basis_universal.lua
@@ -19,6 +19,10 @@ flags {
   "NoPCH"
 }
 
+excludes {
+  "basisu_tool.cpp"
+}
+
 files {
   "encoder/**.h",
   "encoder/**.cpp",


### PR DESCRIPTION
The 'basisu_tool.cpp' file is used when Basis Universal is built as a tool and is not needed when building a library.

https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/833/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/834/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/835/downstreambuildview/
https://runtime-rtc.esri.com/view/vTest/job/vtest/job/3rdparty_libraries-interface/836/downstreambuildview/