### PR TITLE
enable zstd support

### DIFF
--- a/basis_universal.lua
+++ b/basis_universal.lua
@@ -7,8 +7,7 @@ configuration { "*" }
 uuid "E2587158-A6F8-4BF3-9A7D-9CB1C2F0A5FE"
 
 defines {
-  "BASISU_NO_ITERATOR_DEBUG_LEVEL",
-  "BASISD_SUPPORT_KTX2_ZSTD=0"
+  "BASISU_NO_ITERATOR_DEBUG_LEVEL"
 }
 
 includedirs {
@@ -22,6 +21,8 @@ files {
 
   "transcoder/**.h",
   "transcoder/**.cpp",
+  "zstd/**.h",
+  "zstd/**.c"
 }
 
 excludes {


### PR DESCRIPTION

Some KTX2 textures have ZSTD compression. We need to enable it to support this kinds of textures