### PR TITLE
Revert "enable zstd support"

### DIFF
--- a/basis_universal.lua
+++ b/basis_universal.lua
@@ -7,7 +7,8 @@ configuration { "*" }
 uuid "E2587158-A6F8-4BF3-9A7D-9CB1C2F0A5FE"
 
 defines {
-  "BASISU_NO_ITERATOR_DEBUG_LEVEL"
+  "BASISU_NO_ITERATOR_DEBUG_LEVEL",
+  "BASISD_SUPPORT_KTX2_ZSTD=0"
 }
 
 includedirs {
@@ -21,8 +22,6 @@ files {
 
   "transcoder/**.h",
   "transcoder/**.cpp",
-  "zstd/**.h",
-  "zstd/**.c"
 }
 
 excludes {


### PR DESCRIPTION
zstd is a separate 3rd party that is bundled with basis_universal, and needs separate legal approval.
Revert zstd support until we have got legal approval.